### PR TITLE
Add support for context fieldResolver

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,9 +147,9 @@ function wrapField(field: GraphQLField<any, any>): void {
     const extensionStack = context && context._extensionStack;
     const handler = extensionStack && extensionStack.willResolveField(source, args, context, info);
 
-    // If no resolver has been defined for a field, use the default field resolver
+    // If no resolver has been defined for a field, use the default field resolver on context,
+    // if available or fallback to defaultFieldResolver as a final fallback.
     // (which matches the behavior of graphql-js when there is no explicit resolve function defined).
-    // TODO: Find a way to respect custom field resolvers, see https://github.com/graphql/graphql-js/pull/865
     try {
       const contextFieldResolver = (context && context.fieldResolver) || defaultFieldResolver;
       const result = (fieldResolver || contextFieldResolver)(source, args, context, info);

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,8 @@ function wrapField(field: GraphQLField<any, any>): void {
     // (which matches the behavior of graphql-js when there is no explicit resolve function defined).
     // TODO: Find a way to respect custom field resolvers, see https://github.com/graphql/graphql-js/pull/865
     try {
-      const result = (fieldResolver || defaultFieldResolver)(source, args, context, info);
+      const contextFieldResolver = (context && context.fieldResolver) || defaultFieldResolver;
+      const result = (fieldResolver || contextFieldResolver)(source, args, context, info);
       whenResultIsFinished(result, () => {
         handler && handler(result);
       });


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-server/issues/716

Referenced: https://github.com/graphql/graphql-js/pull/865/files

Looks like we can use `context.fieldResolver` to access the custom field resolver if it exists. Tested with linked package and my tracing-enabled GQL requests now return data like I expect!