### PR TITLE
whenResultIsFinished fix for array results

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,12 +174,12 @@ function whenResultIsFinished(result: any, callback: () => void) {
       if (value && typeof value.then === 'function') {
         promises.push(value);
       }
-      if (promises.length > 0) {
-        Promise.all(promises).then(callback, callback);
-      } else {
-        callback();
-      }
     });
+    if (promises.length > 0) {
+      Promise.all(promises).then(callback, callback);
+    } else {
+      callback();
+    }
   } else {
     callback();
   }


### PR DESCRIPTION
If a resolver returns an empty array, the callback isn't called at all.
If the resolver returns a non-empty array, the callback is invoked once for every element.

This is because the code checks the length of promises + either calls Promise.all or the callback directly on each loop iteration.  Fix is to move that length check + Promise.all + else-call-callback after the loop.